### PR TITLE
Use virtual pipes for stdio

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Handle {
+    /// Discard the I/O
+    Null,
+
     /// Inherit from the parent process
     Inherit,
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -4,7 +4,7 @@ use crate::config::Handle;
 use crate::virtfs::TarDirEntry;
 use std::convert::TryFrom;
 use std::rc::Rc;
-use wasi_common::virtfs::FileContents;
+use wasi_common::virtfs::{pipe::ReadPipe, pipe::WritePipe, FileContents};
 
 /// The error codes of workload execution.
 #[derive(Debug)]
@@ -102,7 +102,7 @@ pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
     if let Some(deploy_config) = deploy_config {
         match deploy_config.stdio.stdin {
             Some(Handle::Inherit) => {
-                builder.inherit_stdin();
+                builder.stdin(ReadPipe::new(std::io::stdin()));
             }
             Some(Handle::File(path)) => {
                 let file = std::fs::OpenOptions::new().read(true).open(&path)?;
@@ -124,11 +124,14 @@ pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
                     }
                 }
             }
-            _ => {}
+            Some(Handle::Null) => {}
+            _ => {
+                unreachable!();
+            }
         }
         match deploy_config.stdio.stdout {
             Some(Handle::Inherit) => {
-                builder.inherit_stdout();
+                builder.stdout(WritePipe::new(std::io::stdout()));
             }
             Some(Handle::File(path)) => {
                 let file = std::fs::OpenOptions::new()
@@ -138,11 +141,14 @@ pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
                     .open(&path)?;
                 builder.stdout(wasi_common::OsFile::try_from(file)?);
             }
-            _ => {}
+            Some(Handle::Null) => {}
+            _ => {
+                unreachable!();
+            }
         }
         match deploy_config.stdio.stderr {
             Some(Handle::Inherit) => {
-                builder.inherit_stderr();
+                builder.stderr(WritePipe::new(std::io::stderr()));
             }
             Some(Handle::File(path)) => {
                 let file = std::fs::OpenOptions::new()
@@ -152,7 +158,10 @@ pub fn run<T: AsRef<[u8]>, U: AsRef<[u8]>, V: std::borrow::Borrow<(U, U)>>(
                     .open(&path)?;
                 builder.stderr(wasi_common::OsFile::try_from(file)?);
             }
-            _ => {}
+            Some(Handle::Null) => {}
+            _ => {
+                unreachable!();
+            }
         }
     }
     builder.preopened_virt(root.into(), ".");


### PR DESCRIPTION
Otherwise wasi-common checks the rights of those file descriptors with
statx, ioctl, and fcntl:
```console
  $ strace ./target/debug/wasmtime tests/wasm/hello_wasi_snapshot1.wat
  ...
  statx(0, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_ALL, {stx_mask=STATX_BASIC_STATS, stx_attributes=0, stx_mode=S_IFCHR|0620, stx_size=0, ...}) = 0
  ioctl(0, TCGETS, {B38400 opost isig icanon echo ...}) = 0
  fcntl(0, F_GETFL)                       = 0x2 (flags O_RDWR)
```
Originally reported in enarx/enarx#661.