### PR TITLE
Rework the bundle for better defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,9 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+#[serde(rename_all = "lowercase")]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum Handle {
+pub enum ReadOnly {
     /// Discard the I/O
     Null,
 
@@ -17,14 +18,41 @@ pub enum Handle {
     Bundle(PathBuf),
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Stdio {
-    pub stdin: Option<Handle>,
-    pub stdout: Option<Handle>,
-    pub stderr: Option<Handle>,
+impl Default for ReadOnly {
+    fn default() -> Self {
+        Self::Inherit
+    }
 }
 
+#[serde(rename_all = "lowercase")]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum WriteOnly {
+    /// Discard the I/O
+    Null,
+
+    /// Inherit from the parent process
+    Inherit,
+
+    /// External file
+    File(PathBuf),
+}
+
+impl Default for WriteOnly {
+    fn default() -> Self {
+        Self::Inherit
+    }
+}
+
+#[serde(default)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Stdio {
+    pub stdin: ReadOnly,
+    pub stdout: WriteOnly,
+    pub stderr: WriteOnly,
+}
+
+#[serde(default)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub stdio: Stdio,
 }


### PR DESCRIPTION
By using defaults, we can better manage the experience when there is no config
or when critical sections of the config are missing.