### PR TITLE
Elide enarx-keepldr argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,8 @@ const FD: std::os::unix::io::RawFd = 3;
 fn main() {
     let _ = env_logger::try_init_from_env(env_logger::Env::default());
 
-    let mut args = std::env::args().skip(1);
+    let mut args = std::env::args()
+        .skip_while(|s| s.ends_with("enarx-keepldr") || s.ends_with("enarx-wasmldr"));
     let vars = std::env::vars();
 
     let mut reader = if let Some(path) = args.next() {


### PR DESCRIPTION
enarx-keepldr commit f0d9c7e39eb29d084be394d9a1c38b399ae15496
injects the enarx-keepldr image name into the process command line
arguments to the exec syscall in the event the nil backend is selected.

This accidentally pollutes the arguments list that enarx-wasmldr
passes to the workload run function, as enarx-wasmldr only skips 1
argument because it expects the first argument is simply the path
to the enarx-wasmldr image.

This patch updates the arg skipping logic to account for an
enarx-keepldr nil backend launch so we don't accidentally pollute
the arguments list passed to the workload run function and crash:

$ ENARX_BACKEND=nil 3<>demo.wasm ./enarx-keepldr exec enarx-wasmldr
thread 'main' panicked at 'Failed to run workload: IoError(Kind(InvalidInput))', src/main.rs:70:52
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
