### PR TITLE
Switch to using the released version of wasmtime crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +103,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "byteorder"
@@ -126,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "cpu-time"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,16 +172,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f065f6889758f817f61a230220d1811ba99a9762af2fb69ae23048314f75ff2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510aa2ab4307644100682b94e449940a0ea15c5887f1d4b9678b8dd5ef31e736"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -164,8 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4cb0c7e87c60d63b35f9670c15479ee4a5e557dd127efab88b2f9b2ca83c9a0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -173,21 +211,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60636227098693e06de8d6d88beea2a7d32ecf8a8030dacdb57c68e06f381826"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6156db73e0c9f65f80c512988d63ec736be0dee3dd66bf951e3e28aed9dc02d3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09cd158c9a820a4cc14a34076811da225cce1d31dc6d03c5ef85b91aef560b9"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -197,8 +238,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7054533ae1fc2048c1a6110bdf8f4314b77c60329ec6a7df79d2cfb84e3dcc1c"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -207,8 +249,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.66.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aee0e0b68eba99f99a4923212d97aca9e44655ca8246f07fffe11236109b0d0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -229,12 +272,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
 name = "cvt"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
 dependencies = [
  "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -537,6 +612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regalloc"
 version = "0.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +670,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -655,6 +753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
+checksum = "4ee5a98e506fb7231a304c3a1bd7c132a55016cf65001e0282480665870dfcb9"
 
 [[package]]
 name = "tempfile"
@@ -826,8 +933,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.19.1"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c411d6c2d133953a492f546f8fba975abf2a5cf462ad4676781281e3e3fb8c5"
 dependencies = [
  "anyhow",
  "cfg-if 0.1.10",
@@ -865,8 +973,9 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "wasmtime"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b87ebd6721f4121e28eeaaa41943548c48bcca04ac9bb063004207e5e7d70"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -890,8 +999,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c01df908e54d40bed80326ade122825d464888991beafd950d186f1be309c2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -902,8 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28962772f96fadb79dc7be5ade135ca55d2b0017a012f4869e2476a03abbe733"
 dependencies = [
  "anyhow",
  "gimli 0.21.0",
@@ -917,8 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c0d7401bf253b7b1f426afd70d285bb23ea9a1c7605d6af788c95db5084edf5"
 dependencies = [
  "anyhow",
  "cfg-if 0.1.10",
@@ -936,8 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c838a108318e7c5a2201addb3d3b27a6ef3d142f0eb0addc815b9c2541e5db5"
 dependencies = [
  "anyhow",
  "cfg-if 0.1.10",
@@ -966,8 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8422b0acce519b74c3ae5db59167c611ea92220e5c334ad406e977277e0f23"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -979,8 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f2689bf523f843555e57e24d59abf0c5013007366b866081d73a15e510b4b2"
 dependencies = [
  "anyhow",
  "cfg-if 0.1.10",
@@ -994,8 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7353f5e79390048128e44b5ceda7255723b2066de4026df9a168b0b2593df71"
 dependencies = [
  "backtrace",
  "cc",
@@ -1014,8 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.19.1"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec8bee7307ba6d9cc9b0573dd4d6d31aeffa1f4a2c1bf543beeca6ba0f2b839"
 dependencies = [
  "anyhow",
  "tracing",
@@ -1029,8 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281eecb5d6089bcfdbbaa623ee9d43024566390651662478c7599663e02c302"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
@@ -1040,8 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.19.1"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d609db0f4c1a097a2a8dbb14eeb6888ee09f7fe0f531823f182e49793f8b873"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,8 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765a40393f114be86ee4194f503b1b17dba23a87da1cc44691d8f35331d6ee76"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1090,8 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5604944e321f6041c52ab6371fe64e33a7a0d29c9efea79be42ce7cd76b7f5"
 dependencies = [
  "thiserror",
  "tracing",
@@ -1101,21 +1222,24 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325e221abe5a9fbcbb2d371e14594bced140cfebfead845efd2dc6ca27911a4e"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
+ "shellexpand",
  "syn",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba4a7993c883a08c8280b9ce345a444ab1686b53336672a34904bc0947d82d1"
 dependencies = [
  "quote",
  "syn",
@@ -1156,8 +1280,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25e4ae373f2f2f7f5f187974ed315719ce74160859027c80deb1f68b3c0c966"
 dependencies = [
  "bitflags",
  "cvt",
@@ -1167,7 +1292,8 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.8.7"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9071fe1b3f2b23e22c3e6148920330c7d8660640240c5d7e1e828d024d23e1b"
 dependencies = [
  "anyhow",
  "log",
@@ -1195,8 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "yanix"
-version = "0.19.0"
-source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306#8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c507c0a2a8a3470686591bd0c706225676493db49b314fb10f03a9d9a5c48b3c"
 dependencies = [
  "bitflags",
  "cfg-if 0.1.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ is-it-maintained-issue-resolution = { repository = "enarx/enarx-wasmldr" }
 is-it-maintained-open-issues = { repository = "enarx/enarx-wasmldr" }
 
 [dependencies]
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime.git", rev = "8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306", default-features = false }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime.git", rev = "8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306", default-features = false }
-wasi-common = { git = "https://github.com/bytecodealliance/wasmtime.git", rev = "8ac4bd1d0d8228b97a88b1841cfc0247e9ef4306", default-features = false }
+wasmtime = { version = "0.20", default-features = false }
+wasmtime-wasi = { version = "0.20", default-features = false }
+wasi-common = { version = "0.20", default-features = false }
 env_logger = "0.8"
 log = "0.4"
 


### PR DESCRIPTION
The 0.20 series should contain all the necessary changes we previously picked from the git rev, though there are some API changes.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
