### PR TITLE
Loosen cargo deny rules, and add ring exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ allow = [
     "CC0-1.0",
     "ISC",
     "MIT",
+    "OpenSSL",
     "Zlib",
 ]
 # Lint level for licenses considered copyleft
@@ -25,7 +26,7 @@ copyleft = "deny"
 # * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
 # * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
+allow-osi-fsf-free = "either"
 # Lint level used when no other predicates are matched
 # 1. License isn't in the allow or deny lists
 # 2. License isn't copyleft
@@ -41,3 +42,11 @@ confidence-threshold = 0.8
 # If true, ignores workspace crates that aren't published, or are only
 # published to private registries
 ignore = false
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]


### PR DESCRIPTION
Signed-off-by: Mark Bestavros <mbestavr@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
