### PR TITLE
Prefer From over Into implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/src/virtfs.rs
+++ b/src/virtfs.rs
@@ -108,9 +108,9 @@ impl TarDirEntry {
     }
 }
 
-impl Into<VirtualDirEntry> for TarDirEntry {
-    fn into(self) -> VirtualDirEntry {
-        match self {
+impl From<TarDirEntry> for VirtualDirEntry {
+    fn from(entry: TarDirEntry) -> Self {
+        match entry {
             TarDirEntry::Directory(map) => {
                 let mut virt = HashMap::new();
                 for (name, entry) in map {


### PR DESCRIPTION
Flagged by clippy:
https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
