### PR TITLE
Bump wasmtime crates to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ is-it-maintained-issue-resolution = { repository = "enarx/enarx-wasmldr" }
 is-it-maintained-open-issues = { repository = "enarx/enarx-wasmldr" }
 
 [dependencies]
-wasmtime = { version = "0.21", default-features = false }
-wasmtime-wasi = { version = "0.21", default-features = false }
-wasi-common = { version = "0.21", default-features = false }
+wasmtime = { version = "0.22", default-features = false }
+wasmtime-wasi = { version = "0.22", default-features = false }
+wasi-common = { version = "0.22", default-features = false }
 env_logger = "0.8"
 log = "0.4"
 


### PR DESCRIPTION
Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
