### PR TITLE
Bring back "load module from fd"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ $ RUST_LOG=enarx_wasmldr=info RUST_BACKTRACE=1 cargo run return_1.wasm
     ]
 ```
 
-On Unix platforms, the command can also read the workload from the
-file descriptor (3):
+On Unix platforms, the command can also read the workload from an open file descriptor:
 ```console
-$ RUST_LOG=enarx_wasmldr=info RUST_BACKTRACE=1 cargo run 3< return_1.wasm
+$ RUST_LOG=enarx_wasmldr=info RUST_BACKTRACE=1 cargo run -- --module-on-fd=3 3< return_1.wasm
 ```
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,14 +2,22 @@
 
 #![allow(missing_docs, unused_variables)] // This is a work-in-progress, so...
 
+use anyhow::{bail, Result};
 use structopt::{clap::AppSettings, StructOpt};
 
-use anyhow::{bail, Result};
 use std::path::PathBuf;
+use std::str::FromStr;
 
-// The main StructOpt for running `wasmldr` directly
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
+
+// The main StructOpt for CLI options
 #[derive(StructOpt, Debug)]
-#[structopt(setting=AppSettings::TrailingVarArg)]
+#[structopt(
+    setting = AppSettings::DeriveDisplayOrder,
+    setting = AppSettings::UnifiedHelpMessage,
+)]
+/// Enarx Keep Configurator and WebAssembly Loader
 pub struct RunOptions {
     /// Pass an environment variable to the program
     #[structopt(
@@ -25,15 +33,24 @@ pub struct RunOptions {
     #[structopt(long, value_name = "FUNCTION")]
     invoke: Option<String>,
 
+    /// Load WebAssembly module from the given FD (must be >=3)
+    #[cfg(unix)]
+    #[structopt(long, value_name = "FD", parse(try_from_str = parse_module_fd))]
+    pub module_on_fd: Option<RawFd>,
+
     // TODO: --inherit-env
     // TODO: --stdin, --stdout, --stderr
     /// Path of the WebAssembly module to run
-    #[structopt(index = 1, required = true, value_name = "MODULE", parse(from_os_str))]
-    pub module: PathBuf,
+    #[structopt(
+        index = 1,
+        required_unless = "module-on-fd",
+        value_name = "MODULE",
+        parse(from_os_str)
+    )]
+    pub module: Option<PathBuf>,
 
-    // NOTE: this has to come last for TrailingVarArg
     /// Arguments to pass to the WebAssembly module
-    #[structopt(value_name = "ARGS")]
+    #[structopt(value_name = "ARGS", last = true)]
     pub args: Vec<String>,
 }
 
@@ -43,4 +60,12 @@ fn parse_env_var(s: &str) -> Result<(String, String)> {
         bail!("must be of the form `NAME=VAL`");
     }
     Ok((parts[0].to_owned(), parts[1].to_owned()))
+}
+
+fn parse_module_fd(s: &str) -> Result<RawFd> {
+    let fd = RawFd::from_str(s)?;
+    if fd <= 2 {
+        bail!("FD must be >= 3");
+    }
+    Ok(fd)
 }


### PR DESCRIPTION
This builds on the previous PR (enarx/enarx-wasmldr#100) and brings back the ability to load the WebAssembly module from an inherited file descriptor, using the new `--module-on-fd NUM` flag. (The docstring in main.rs has been updated accordingly.)

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
